### PR TITLE
Allow uppercase letters and underscores in room URLs

### DIFF
--- a/src/main/java/sh/mob/timer/web/RoomApiController.java
+++ b/src/main/java/sh/mob/timer/web/RoomApiController.java
@@ -36,7 +36,7 @@ public class RoomApiController {
 
   @GetMapping
   @RequestMapping(
-      value = "/{roomId:[a-z0-9-]+}/events",
+      value = "/{roomId:[A-Za-z0-9-_]+}/events",
       produces = MediaType.TEXT_EVENT_STREAM_VALUE)
   public Flux<ServerSentEvent<Object>> getEventStream(
       @PathVariable String roomId, ServerHttpResponse response) {
@@ -68,7 +68,7 @@ public class RoomApiController {
     return Flux.concat(initialHistory, keepAliveFlux.mergeWith(timerRequestFlux));
   }
 
-  @PutMapping("/{roomId:[a-z0-9-]+}")
+  @PutMapping("/{roomId:[A-Za-z0-9-_]+}")
   @ResponseStatus(HttpStatus.ACCEPTED)
   public void publishEvent(@PathVariable String roomId, @RequestBody PutTimerRequest timerRequest) {
     var room = roomRepository.get(roomId);

--- a/src/main/java/sh/mob/timer/web/RoomController.java
+++ b/src/main/java/sh/mob/timer/web/RoomController.java
@@ -16,7 +16,7 @@ public class RoomController {
   }
 
   @GetMapping
-  @RequestMapping(value = "/{roomId:[a-z0-9-]+}")
+  @RequestMapping(value = "/{roomId:[A-Za-z0-9-_]+}")
   public String get(@PathVariable String roomId, Model model) {
     model.addAttribute("room", roomRepository.get(roomId));
     return "room";

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -31,7 +31,7 @@
     <form method="post" class="mb-3">
       <div class="input-group">
         <span class="input-group-text" id="basic-addon3">[[${url}]]</span>
-        <input class="form-control" type="text" id="room" name="room" th:value="${randomRoomName}" placeholder="room /[a-z0-9-]+/" required autofocus />
+        <input class="form-control" type="text" id="room" name="room" th:value="${randomRoomName}" placeholder="room /[A-Za-z0-9-_]+/" required autofocus />
         <button type="submit" class="btn btn-primary">Join</button>
       </div>
     </form>


### PR DESCRIPTION
Hello,

I'd like to suggest a slight change to the room URL matching. In my team we occasionally run into problems where our mob timer room URLs result in `404 Not Found` because they contain either uppercase letters or underscores. This is because we start our mob timers through the mob CLI (e.g. `mob timer 10`) and use something like `MYPROJECT-123_some_change` as our mob branch name. This can sometimes be a little irritating since the mob CLI itself does allow such mob names.

Regardless of whether you accept this minor suggestion, my team and I really enjoy the mob CLI and timer. Thank you for your work!

Also, should this kind of contribution be entirely undesired please let me know.

Kind regards