### PR TITLE
Add quotes around the room name for `~/.mob`

### DIFF
--- a/src/main/resources/templates/room.html
+++ b/src/main/resources/templates/room.html
@@ -150,7 +150,7 @@
     <h5>Integration with the mob tool</h5>
     <ul class="list-unstyled">
       <li>configure in ~/.mob</li>
-      <li><code>MOB_TIMER_ROOM=[[${room.name}]]</code></li>
+      <li><code>MOB_TIMER_ROOM=&quot;[[${room.name}]]&quot;</code></li>
     </ul>
     <ul class="list-unstyled">
       <li>start timer in cli</li>


### PR DESCRIPTION
A small change to add quotes around the room name in the "Integration with the mob tool" message. The message then becomes something like:

> ##### Integration with the mob tool
> configure in ~/.mob
> `MOB_TIMER_ROOM="crazy-sealion-69"`

Without the quotes, [mob](/remotemobprogramming/mob) cannot parse the room name given in the configuration.

Fixes #10