### PR TITLE
Upgrade to Spring Boot 2.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.5.5</version>
+    <version>2.7.1</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>sh.mob</groupId>


### PR DESCRIPTION
This change upgrades Spring Boot to the latest available version (2.7.1).

Currently, Mob Timer uses version 2.5.5 which reached [end of non-commercial support on 2022-05-19](https://spring.io/projects/spring-boot#support). Its transitive dependencies also contain some vulnerabilities which have been fixed in later versions.

Things that were marked as deprecated in Spring Boot 2.5 have been removed in 2.7, but it seems like Mob Timer does not use any such things. After upgrading, the app still seems to run fine and all tests pass.