### PR TITLE
Fix stats page Cypress test

### DIFF
--- a/cypress/cypress/e2e/smoketest.cy.js
+++ b/cypress/cypress/e2e/smoketest.cy.js
@@ -17,8 +17,8 @@ describe('Mob.sh Timer', () => {
   })
 
   it('stats page is available', () => {
-    cy.visit('https://timer.mob.sh/help' + roomId)
-    cy.contains('Help')
+    cy.visit('https://timer.mob.sh/stats')
+    cy.contains('Stats')
   })
 
   it('mob timer works', () => {

--- a/cypress/cypress/e2e/smoketest.cy.js
+++ b/cypress/cypress/e2e/smoketest.cy.js
@@ -12,7 +12,7 @@ describe('Mob.sh Timer', () => {
   })
 
   it('help page is available', () => {
-    cy.visit('https://timer.mob.sh/help' + roomId)
+    cy.visit('https://timer.mob.sh/help')
     cy.contains('Help')
   })
 


### PR DESCRIPTION
The `stats page is available` Cypress test was opening the help page instead of the stats page, and also asserted that the page contains "Help" instead of "Stats".

This fixes the test by opening the correct URL and asserting the right thing.

Additionally, removed the unnecessary `roomId` from the help test (probably a copy-paste artifact from the previous test).